### PR TITLE
フォント種類変更

### DIFF
--- a/resources/js/components/App.vue
+++ b/resources/js/components/App.vue
@@ -23,5 +23,7 @@ export default {
 
 main{
     color:#333;
+    font-family: 'ヒラギノ明朝 ProN','Hiragino Mincho ProN','Yu Mincho Light','YuMincho','Yu Mincho','游明朝体',sans-serif;
+
 }
 </style>

--- a/resources/js/components/pages/EditPaperNovel.vue
+++ b/resources/js/components/pages/EditPaperNovel.vue
@@ -227,6 +227,8 @@ outline: none;
 
 a,p{
     color: #333;
+    font-family: 'ヒラギノ明朝 ProN','Hiragino Mincho ProN','Yu Mincho Light','YuMincho','Yu Mincho','游明朝体',sans-serif;
+
 }
 
 a:hover{

--- a/resources/js/components/pages/Hero.vue
+++ b/resources/js/components/pages/Hero.vue
@@ -95,6 +95,8 @@ a:hover{
     grid-template-rows: 1fr 1fr 1fr 1fr;
     grid-template-columns: 1fr 1fr 1fr;
     color: #333;
+    font-family: 'Lao MN','serif';
+
 }
 .hero_img {
     grid-row: 1 / 5;
@@ -118,5 +120,6 @@ a:hover{
 }
 .v-btn{
     color: #333;
+    font-family: 'ヒラギノ明朝 ProN','Hiragino Mincho ProN','Yu Mincho Light','YuMincho','Yu Mincho','游明朝体',sans-serif;
 }
 </style>

--- a/resources/js/components/pages/Profile.vue
+++ b/resources/js/components/pages/Profile.vue
@@ -62,8 +62,11 @@ outline: none;
 
 p{
     color: #333;
+    font-family: 'ヒラギノ明朝 ProN','Hiragino Mincho ProN','Yu Mincho Light','YuMincho','Yu Mincho','游明朝体',sans-serif;
+
 }
 a:hover{
     text-decoration: none;
 }
+
 </style>

--- a/resources/js/components/pages/ReadFirstSentence.vue
+++ b/resources/js/components/pages/ReadFirstSentence.vue
@@ -155,6 +155,12 @@ outline: none;
     margin: auto;
     color: #333;
     font-size: 20px;
+
+}
+
+p{
+    font-family: 'ヒラギノ明朝 ProN','Hiragino Mincho ProN','Yu Mincho Light','YuMincho','Yu Mincho','游明朝体',sans-serif;
+
 }
 
 a{

--- a/resources/js/components/pages/ReadPaper.vue
+++ b/resources/js/components/pages/ReadPaper.vue
@@ -66,6 +66,10 @@ export default {
 outline: none;
 }
 
+.container{
+    font-family: 'ヒラギノ明朝 ProN','Hiragino Mincho ProN','Yu Mincho Light','YuMincho','Yu Mincho','游明朝体',sans-serif;
+}
+
 .paper {
     margin: auto;
     padding-top: 50px;

--- a/resources/js/components/pages/Top.vue
+++ b/resources/js/components/pages/Top.vue
@@ -102,7 +102,13 @@ a:hover{
     opacity: 0.8;
 }
 
+p{
+    font-family: 'Lao MN','serif';
+}
+
 .show-btns {
     color: rgba(255, 255, 255, 1) !important;
 }
+
+
 </style>

--- a/resources/js/components/pages/WriteFirstSentence.vue
+++ b/resources/js/components/pages/WriteFirstSentence.vue
@@ -1,14 +1,14 @@
 <template>
     <div>
         <!-- 主人公の名前を表示 -->
-        <p>{{ HeroData.hero_name }}</p>
+        <p class="heroName">{{ HeroData.hero_name }}</p>
 
         <!-- タイトル入力 -->
         <v-form>
             <p
                 class="paper"
                 contenteditable="true"
-                placeholder="最初の一文を書いてください"
+                placeholder="最初の一文を書いてください。"
                 id="first_sentence"
             >{{ text }}</p>
             <br />
@@ -132,6 +132,13 @@ export default {
 outline: none;
 }
 
+.heroName{
+    font-family: 'Lao MN','serif';
+}
+
+form{
+    font-family: 'ヒラギノ明朝 ProN','Hiragino Mincho ProN','Yu Mincho Light','YuMincho','Yu Mincho','游明朝体',sans-serif;
+}
 
 .paper {
     display: block;

--- a/resources/js/components/pages/profiles/PaperNovelClosed.vue
+++ b/resources/js/components/pages/profiles/PaperNovelClosed.vue
@@ -1,5 +1,5 @@
 <template>
-    <div>
+    <div class="font">
         <v-row>
             <v-col cols="12">
                 <v-row
@@ -141,6 +141,10 @@ export default {
 <style scoped>
 *:focus {
 outline: none;
+}
+
+.font{
+    font-family: 'ヒラギノ明朝 ProN','Hiragino Mincho ProN','Yu Mincho Light','YuMincho','Yu Mincho','游明朝体',sans-serif;
 }
 
 .novel_card {

--- a/resources/js/components/pages/profiles/PaperNovelOpened.vue
+++ b/resources/js/components/pages/profiles/PaperNovelOpened.vue
@@ -1,5 +1,5 @@
 <template>
-    <div>
+    <div class="font">
         <v-row>
             <v-col cols="12">
                 <v-row
@@ -144,6 +144,10 @@ export default {
 <style scoped>
 *:focus {
 outline: none;
+}
+
+.font{
+    font-family: 'ヒラギノ明朝 ProN','Hiragino Mincho ProN','Yu Mincho Light','YuMincho','Yu Mincho','游明朝体',sans-serif;
 }
 
 .novel_card {


### PR DESCRIPTION
Hero.vueの英語テキストを「Lao MN」で統一
執筆ページの入力される文字は全て「明朝体」に変更