### PR TITLE
書くページUI修正

### DIFF
--- a/resources/js/components/App.vue
+++ b/resources/js/components/App.vue
@@ -28,4 +28,5 @@ main{
     font-family: 'ヒラギノ明朝 ProN','Hiragino Mincho ProN','Yu Mincho Light','YuMincho','Yu Mincho','游明朝体',sans-serif;
 
 }
+
 </style>

--- a/resources/js/components/items/HeaderComponent.vue
+++ b/resources/js/components/items/HeaderComponent.vue
@@ -1,5 +1,5 @@
 <template>
-    <v-app-bar>
+    <v-app-bar hide-on-scroll>
         <v-col cols="3" class="spn">
             <router-link :to="{ name: 'Top' }" style="text-decoration: none">
                 <v-btn id="pen" icon>

--- a/resources/js/components/items/Hint.vue
+++ b/resources/js/components/items/Hint.vue
@@ -51,7 +51,7 @@
                         cols="30"
                         rows="2"
                         v-model="answers.q_5"
-                    ></textarea>
+                    ></textarea><p></p>
                     <button style="border:solid 2px #000" @click="saveAnswers">
                         &nbsp;保存&nbsp;
                     </button>
@@ -117,7 +117,7 @@ export default {
 }
 
 .icon {
-    width: 100px;
+    width: 60px;
 }
 #overlay {
     /*　要素を重ねた時の順番　*/

--- a/resources/js/components/pages/EditStoryPaper.vue
+++ b/resources/js/components/pages/EditStoryPaper.vue
@@ -1,8 +1,15 @@
 <template>
-    <div>
-        <v-row>
+    <div class="wrap">
             <!-- ボタンたち -->
-            <div>
+            <div class="buttons">
+                <v-img
+                    class="icon"
+                    height="60px"
+                    src="img/write-page/continue.png"
+                    @click="$router.go(-1)"
+                >
+                </v-img>
+
                 <!-- 一時保存ボタン -->
                 <router-link
                     :to="{
@@ -14,35 +21,39 @@
                 >
                     <v-img
                         class="icon"
+                        height="60px"
                         src="img/write-page/book.png"
                         @click="editPaper"
                     >
                     </v-img>
                 </router-link>
-                <Hint />
 
-                <v-img
-                    class="icon"
-                    src="img/write-page/continue.png"
-                    @click="$router.go(-1)"
-                >
-                </v-img>
             </div>
-            <!-- 小説入力 -->
-            <div class="input-area">
+
+            <v-row>
+
                 <!-- 小説入力 -->
-                <div id="paper_text">
-                    <p
-                        class="paper"
-                        contenteditable="true"
-                        id="story_text_input"
-                    >
-                        {{ PaperNovelData.text }}
-                    </p>
+                <div class="input-area">
+                    <!-- 小説入力 -->
+                    <div id="paper_text">
+                        <p
+                            class="paper"
+                            contenteditable="true"
+                            id="story_text_input"
+                        >
+                            {{ PaperNovelData.text }}
+                        </p>
+                    </div>
                 </div>
-            </div>
-        </v-row>
+            </v-row>
         <!-- 入力エリアここまで -->
+            <div class="icons">
+                <img :src="'/img/write-page/write.png'"  class="icon" alt="write"/>
+                <img :src="'/img/write-page/font.png'"  class="icon" alt="read" />
+                <img :src="'/img/write-page/font-size.png'" class="icon" alt="read" />
+                <Hint />
+            </div>
+
     </div>
 </template>
 
@@ -187,7 +198,7 @@ export default {
     -webkit-writing-mode: vertical-rl;
     -ms-writing-mode: tb-rl;
     writing-mode: vertical-rl;
-    font-size: 20px;
+    font-size: 18px;
     line-height: 2em;
     overflow-x: scroll;
     outline: none;
@@ -202,9 +213,10 @@ export default {
 }
 .input-area {
     margin: 0 auto;
-    padding-top: 50px;
-    height: 700px;
+    padding-top: 25px;
+    height: 600px;
     width: 800px;
+    margin-top: 2em;
     display: grid;
     grid-template-columns: 150px 1fr;
     border: 1px dotted #a9a9a9;
@@ -215,8 +227,8 @@ export default {
 }
 
 #story_text_input > div {
-    height: 640px;
-    font-size: 20px;
+    height: 582px;
+    font-size: 18px;
 }
 
 #story_text_input {
@@ -224,7 +236,36 @@ export default {
     /* border: 1px solid #000000; */
 }
 
-.icon {
-    width: 100px;
+.icons{
+    display: flex;
+    flex-direction: column;
+    margin:2em 2em;
+
 }
+
+.buttons{
+    display: flex;
+    flex-direction : column-reverse;
+    height: 120px;
+    margin-left:3em;
+    margin-top:500px;
+}
+
+.icon,
+.v-responsive__sizer,
+#app > div > main > div > div > div.buttons > div > div.v-responsive__content,
+.v-image__image,
+.v-image__image--cover,
+#app > div > main > div > div > div.buttons > div > div.v-image__image.v-image__image--cover{
+    width: 60px;
+    height: 60px!important;
+}
+
+.wrap{
+    display: flex;
+}
+
+</style>
+<style>
+
 </style>

--- a/resources/js/components/pages/Top.vue
+++ b/resources/js/components/pages/Top.vue
@@ -99,3 +99,8 @@ p {
 }
 
 </style>
+<style>
+#app > div > header{
+    display: block;
+}
+</style>

--- a/resources/js/components/pages/WriteFirstSentence.vue
+++ b/resources/js/components/pages/WriteFirstSentence.vue
@@ -1,29 +1,68 @@
 <template>
-    <div>
-        <!-- 主人公の画像を表示 -->
-        <v-img :src="img_url" id="hero_img"></v-img>
-        <Hint />
+    <div class="wrap">
+            <v-content>
+
+        <v-navigation-drawer
+            class="nav accent-4"
+            permanent
+        >
+        <v-list>
+            <v-img :src="img_url" id="hero_img"></v-img>
+
+            <v-list-item
+                v-for="item in items"
+                :key="item.title"
+                link
+            >
+
+            <v-list-item-icon>
+                <!-- 主人公の画像を表示 -->
+                <v-icon>{{ item.icon }}</v-icon>
+            </v-list-item-icon>
+
+            <v-list-item-content>
+                <v-list-item-title>{{ item.title }}</v-list-item-title>
+            </v-list-item-content>
+        </v-list-item>
+        </v-list>
+
+    </v-navigation-drawer>
+    </v-content>
+
         <!-- タイトル入力 -->
-        <v-form>
-            <div class="input-area">
-                <div id="paper_text">
-                    <div
-                        class="paper"
-                        contenteditable="true"
-                        placeholder="最初の一文を書いてください。"
-                        id="first_sentence"
-                    >{{ text }}</div>
-                    <br />
-                    <v-btn
-                        style="display: none;"
-                        id="save"
-                        dark
-                        @click="saveFirstSentence"
-                        >完了</v-btn
-                    >
-                </div>
+    <v-content>
+        <v-container fluid>
+    <v-form>
+        <div class="input-area">
+            <div id="paper_text">
+                <div
+                    class="paper"
+                    contenteditable="true"
+                    placeholder="第一文を書いて、句読点（。）を打ちましょう。"
+                    id="first_sentence"
+                >{{ text }}</div>
+                <br />
+                <v-btn
+                    style="display: none;"
+                    id="save"
+                    dark
+                    @click="saveFirstSentence"
+                    >1ページ目を書く</v-btn
+                >
             </div>
-        </v-form>
+        </div>
+    </v-form>
+        </v-container>
+    </v-content>
+    <div class="icons">
+        <img :src="'/img/write-page/write.png'"  class="icon" alt="write"/>
+        <img :src="'/img/write-page/font.png'"  class="icon" alt="read" />
+        <img :src="'/img/write-page/font-size.png'" class="icon" alt="read" />
+        <Hint />
+        <a href="/" alt="daiki">
+            <img :src="'/img/write-page/continue.png'" class="icon" alt="read" />
+        </a>
+    </div>
     </div>
 </template>
 
@@ -47,14 +86,19 @@ export default {
             text: "",
             charaCount: "",
             lineCount: "",
-            img_url: ""
+            img_url: "",
+            // items: [
+            //     { title: 'Dashboard' },
+            //     { title: 'Account' },
+            //     { title: 'Admin' },
+            // ],
         };
     },
     created() {
         // this.fetchHeroData(this.$route.params.hero_id);
         this.showHero();
         //ログインしてなかったらモーダル表示
-        if (!this.$store.state.login) this.$store.state.drawerLoginModal = true;
+        // if (!this.$store.state.login) this.$store.state.drawerLoginModal = true;
         // this.img_url = "img/charactors/" + this.$store.state.HeroData.img_url;
     },
     mounted() {
@@ -248,6 +292,7 @@ form {
 #paper_text {
     grid-row: 1 / 10;
     grid-column: 1 / 10;
+    margin-top: 1em;
     /* border: 1px solid #000000; */
 
     /* display: grid; */
@@ -256,15 +301,56 @@ form {
 
 #first_sentence {
     margin: 0 auto 0;
-    height: 640px;
-    font-size: 20px;
+    height: 582px;
+    font-size: 18px;
 
     /* border: 1px solid #000000; */
 }
 
 #hero_img {
-    margin-top: 5%;
-    height: 100%;
-    width: 200px;
+    margin: 10% auto;
+    height: 200px;
+    width: 150px;
+    object-fit: cover;
+    object-position: 100% 0%
 }
+
+.nav{
+    background-color: #F7E9D1;
+}
+
+.wrap{
+    display: flex;
+}
+
+v-navigation-drawer{
+    height: 100vh;
+}
+
+.icons{
+    display: flex;
+    flex-direction: column;
+    margin:1em 4em;
+
+}
+
+.icon{
+    width: 60px;
+    height: auto;
+}
+#app > div > header{
+    display: none!important;
+}
+
+
+</style>
+<style>
+#app > div > main > div > div > main:nth-child(2) > div{
+    margin-right: 0;
+    flex: 0 0 auto!important;
+    flex-grow: 0!important;
+    flex-shrink: 0!important;
+    flex-basis: auto!important;
+}
+
 </style>


### PR DESCRIPTION
書くページのUI変更
- 完了ボタンの位置
- 各種アイコンの位置
- XDのレイアウトになるべく寄せた
- ヘッダースクロールすると消える仕様にした
- プレースホルダーを「第一文を書いて、句読点（。）を打ちましょう。」に変更
- 第一文を書くところの、左上の主人公画像をTOPの姿に変更
- 「完了」を「1ページ目を書く」に変更